### PR TITLE
Fixed CONVERT_TZ errors

### DIFF
--- a/src/main/kotlin/com/tumugin/aisu/infra/repository/exposed/DateFormatWithTZFunction.kt
+++ b/src/main/kotlin/com/tumugin/aisu/infra/repository/exposed/DateFormatWithTZFunction.kt
@@ -1,7 +1,9 @@
 package com.tumugin.aisu.infra.repository.exposed
 
+import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
+import kotlinx.datetime.offsetAt
 import org.jetbrains.exposed.sql.CharColumnType
 import org.jetbrains.exposed.sql.ExpressionWithColumnType
 import org.jetbrains.exposed.sql.QueryBuilder
@@ -11,6 +13,14 @@ class DateFormatWithTZFunction<T : ExpressionWithColumnType<Instant>>(
   private val exp: T, private val format: String, private val fromTZ: TimeZone, private val toTZ: TimeZone
 ) : org.jetbrains.exposed.sql.Function<String>(CharColumnType()) {
   override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder {
-    append("DATE_FORMAT(CONVERT_TZ(", exp, ", '${fromTZ.id}', '${toTZ.id}'), '${format}')")
+    append("DATE_FORMAT(CONVERT_TZ(", exp, ", '${toOffsetString(fromTZ)}', '${toOffsetString(toTZ)}'), '${format}')")
+  }
+
+  private fun toOffsetString(tz: TimeZone): String {
+    val converted = tz.offsetAt(Clock.System.now()).toString()
+    if (converted == "Z") {
+      return "+00:00"
+    }
+    return converted
   }
 }


### PR DESCRIPTION
大変残念なことに、AzureのマネージドMySQLはタイムゾーンテーブルを触るのを許してくれないようだ。仕方ないので、オフセットを手動で入れることにする。